### PR TITLE
[ASAA-190] Global Setting for Metric/Imperial

### DIFF
--- a/androidApp/src/androidMain/kotlin/com/br/kmpdemo/android/KmpDemoApplication.kt
+++ b/androidApp/src/androidMain/kotlin/com/br/kmpdemo/android/KmpDemoApplication.kt
@@ -1,5 +1,6 @@
 package com.br.kmpdemo.android
 
+import MeasurementPreference
 import android.app.Application
 import com.br.kmpdemo.android.di.androidModule
 import com.br.kmpdemo.di.appModule
@@ -15,5 +16,6 @@ class KmpDemoApplication: Application() {
             androidLogger()
             modules(appModule() + androidModule)
         }
+        MeasurementPreference.init(this)
     }
 }

--- a/compose/src/androidMain/kotlin/com/br/kmpdemo/compose/previews/WeatherDetailsPreview.kt
+++ b/compose/src/androidMain/kotlin/com/br/kmpdemo/compose/previews/WeatherDetailsPreview.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
+import com.br.kmpdemo.compose.previews.utils.MockData
 import com.br.kmpdemo.compose.resources.theme.KmpDemoTheme
 import com.br.kmpdemo.compose.ui.weatherDetails.airQuality.AirQualityEnum
 import com.br.kmpdemo.compose.ui.weatherDetails.airQuality.AirQualityWidget
@@ -14,15 +15,11 @@ import com.br.kmpdemo.compose.ui.weatherDetails.feelsLike.FeelsLikeState
 import com.br.kmpdemo.compose.ui.weatherDetails.humidity.HumidityState
 import com.br.kmpdemo.compose.ui.weatherDetails.humidity.HumidityWidget
 import com.br.kmpdemo.compose.ui.weatherDetails.pressure.BarometricPressureState
-import com.br.kmpdemo.compose.ui.weatherDetails.rainFall.RainFallState
 import com.br.kmpdemo.compose.ui.weatherDetails.rainFall.RainFallWidget
 import com.br.kmpdemo.compose.ui.weatherDetails.sunrise_sunset.SunriseSunsetState
 import com.br.kmpdemo.compose.ui.weatherDetails.sunrise_sunset.SunriseSunsetWidget
 import com.br.kmpdemo.compose.ui.weatherDetails.uvIndex.UVIndexEnum
 import com.br.kmpdemo.compose.ui.weatherDetails.uvIndex.UvIndexWidget
-import com.br.kmpdemo.compose.ui.weatherDetails.visibility.VisibilityState
-import com.br.kmpdemo.compose.ui.weatherDetails.wind.WindDirectionEnum
-import com.br.kmpdemo.compose.ui.weatherDetails.wind.WindState
 import com.br.kmpdemo.compose.ui.weatherDetails.wind.WindWidget
 
 @Composable
@@ -75,8 +72,8 @@ fun HumidityPreview() {
 fun RainFallPreview() {
     KmpDemoTheme {
         Row {
-            RainFallWidget(RainFallState(1.8, 1.2))
-            RainFallWidget(RainFallState())
+            RainFallWidget(MockData.getMockHomeState())
+            RainFallWidget(MockData.getMockHomeState(isError = true))
         }
     }
 }
@@ -86,8 +83,8 @@ fun RainFallPreview() {
 fun VisibilityPreview() {
     KmpDemoTheme {
         Row {
-            VisibilityWidget(VisibilityState("8 km"))
-            VisibilityWidget(VisibilityState())
+            VisibilityWidget(MockData.getMockHomeState())
+            VisibilityWidget(MockData.getMockHomeState(isError = true))
         }
     }
 }
@@ -141,16 +138,8 @@ fun WindPreview() {
     KmpDemoTheme {
         Column {
             Row {
-                WindWidget(WindState(windDirection = WindDirectionEnum.N, windSpeed = "9.7"))
-                WindWidget(WindState(windDirection = WindDirectionEnum.ESE, windSpeed = "3.2"))
-            }
-            Row {
-                WindWidget(WindState(windDirection = WindDirectionEnum.W, windSpeed = "9.7"))
-                WindWidget(WindState(windDirection = WindDirectionEnum.WNW, windSpeed = "3.2"))
-            }
-            Row {
-                WindWidget(WindState(windDirection = WindDirectionEnum.SSE, windSpeed = "9.7"))
-                WindWidget(WindState(windDirection = WindDirectionEnum.N))
+                WindWidget(MockData.getMockHomeState(isError = true))
+                WindWidget(MockData.getMockHomeState())
             }
         }
     }

--- a/compose/src/androidMain/kotlin/com/br/kmpdemo/compose/previews/utils/MockData.kt
+++ b/compose/src/androidMain/kotlin/com/br/kmpdemo/compose/previews/utils/MockData.kt
@@ -14,6 +14,7 @@ import com.br.kmpdemo.compose.ui.weatherDetails.uvIndex.UVIndexEnum
 import com.br.kmpdemo.compose.ui.weatherDetails.visibility.VisibilityState
 import com.br.kmpdemo.compose.ui.weatherDetails.wind.WindDirectionEnum
 import com.br.kmpdemo.compose.ui.weatherDetails.wind.WindState
+import com.br.kmpdemo.utils.MeasurementType
 import kotlin.random.Random
 
 object MockData {
@@ -81,7 +82,8 @@ object MockData {
             visibilityState = mutableStateOf(VisibilityState()),
             windState = mutableStateOf(
                 WindState(windDirection = WindDirectionEnum.N)
-            )
+            ),
+            measurementPref = mutableStateOf(MeasurementType.IMPERIAL)
         )
 
         return HomeState(
@@ -112,6 +114,7 @@ object MockData {
                     windSpeed = "9.7"
                 )
             ),
+            measurementPref = mutableStateOf(MeasurementType.IMPERIAL)
         )
     }
 

--- a/compose/src/commonMain/kotlin/com/br/kmpdemo/compose/ui/forecasts/DailyForecastChip.kt
+++ b/compose/src/commonMain/kotlin/com/br/kmpdemo/compose/ui/forecasts/DailyForecastChip.kt
@@ -34,10 +34,9 @@ fun DailyForecastChip(state: ForecastState) {
                     contentDescription = stringResource(SharedRes.strings.weatherIcon),
                 )
                 Text(
-                    stringResource(
-                        SharedRes.strings.input_percentage, precipProbability ?:
-                        SharedRes.strings.number_error
-                    ),
+                    precipProbability?.let { probability ->
+                        stringResource(SharedRes.strings.input_percentage, probability)
+                    } ?: stringResource(SharedRes.strings.number_error),
                     color = Colors.inverseOnSurface,
                     style = MaterialTheme.typography.labelLarge.semiBold()
                 )

--- a/compose/src/commonMain/kotlin/com/br/kmpdemo/compose/ui/forecasts/HourlyForecastChip.kt
+++ b/compose/src/commonMain/kotlin/com/br/kmpdemo/compose/ui/forecasts/HourlyForecastChip.kt
@@ -34,10 +34,9 @@ fun HourlyForecastChip(state: ForecastState) {
                     contentDescription = stringResource(SharedRes.strings.weatherIcon),
                 )
                 Text(
-                    stringResource(
-                        SharedRes.strings.input_percentage,
-                        precipProbability ?: SharedRes.strings.number_error
-                    ),
+                    precipProbability?.let { probability ->
+                        stringResource(SharedRes.strings.input_percentage, probability)
+                    } ?: stringResource(SharedRes.strings.number_error),
                     color = Colors.inverseOnSurface,
                     style = MaterialTheme.typography.labelLarge.semiBold()
                 )

--- a/compose/src/commonMain/kotlin/com/br/kmpdemo/compose/ui/home/HomeState.kt
+++ b/compose/src/commonMain/kotlin/com/br/kmpdemo/compose/ui/home/HomeState.kt
@@ -14,6 +14,7 @@ import com.br.kmpdemo.compose.ui.weatherDetails.uvIndex.UVIndexEnum
 import com.br.kmpdemo.compose.ui.weatherDetails.visibility.VisibilityState
 import com.br.kmpdemo.compose.ui.weatherDetails.wind.WindState
 import com.br.kmpdemo.models.RealTime
+import com.br.kmpdemo.utils.MeasurementType
 
 data class HomeState(
     /// Forecasts
@@ -35,5 +36,8 @@ data class HomeState(
     val sunriseSunsetState: State<SunriseSunsetState?> = mutableStateOf(null),
     val uvIndexState: State<UVIndexEnum?> = mutableStateOf(null),
     val visibilityState: State<VisibilityState?> = mutableStateOf(null),
-    val windState: State<WindState?> = mutableStateOf(null)
+    val windState: State<WindState?> = mutableStateOf(null),
+
+    // Units
+    val measurementPref: State<MeasurementType?> = mutableStateOf(null)
 )

--- a/compose/src/commonMain/kotlin/com/br/kmpdemo/compose/ui/weatherDetails/WeatherDetails.kt
+++ b/compose/src/commonMain/kotlin/com/br/kmpdemo/compose/ui/weatherDetails/WeatherDetails.kt
@@ -15,14 +15,11 @@ import com.br.kmpdemo.compose.ui.weatherDetails.feelsLike.FeelsLikeState
 import com.br.kmpdemo.compose.ui.weatherDetails.humidity.HumidityState
 import com.br.kmpdemo.compose.ui.weatherDetails.humidity.HumidityWidget
 import com.br.kmpdemo.compose.ui.weatherDetails.pressure.BarometricPressureState
-import com.br.kmpdemo.compose.ui.weatherDetails.rainFall.RainFallState
 import com.br.kmpdemo.compose.ui.weatherDetails.rainFall.RainFallWidget
 import com.br.kmpdemo.compose.ui.weatherDetails.sunrise_sunset.SunriseSunsetState
 import com.br.kmpdemo.compose.ui.weatherDetails.sunrise_sunset.SunriseSunsetWidget
 import com.br.kmpdemo.compose.ui.weatherDetails.uvIndex.UVIndexEnum
 import com.br.kmpdemo.compose.ui.weatherDetails.uvIndex.UvIndexWidget
-import com.br.kmpdemo.compose.ui.weatherDetails.visibility.VisibilityState
-import com.br.kmpdemo.compose.ui.weatherDetails.wind.WindState
 import com.br.kmpdemo.compose.ui.weatherDetails.wind.WindWidget
 
 @Composable
@@ -46,8 +43,8 @@ fun WeatherDetails(state: HomeState) {
             }
 
             WeatherDetailsRow {
-                WindWidget(windState.value ?: WindState())
-                RainFallWidget(rainFallState.value ?: RainFallState())
+                WindWidget(state)
+                RainFallWidget(state)
             }
 
             WeatherDetailsRow {
@@ -56,7 +53,7 @@ fun WeatherDetails(state: HomeState) {
             }
 
             WeatherDetailsRow {
-                VisibilityWidget(visibilityState.value ?: VisibilityState())
+                VisibilityWidget(state)
                 BarometricPressureWidget(pressureState.value ?: BarometricPressureState())
             }
         }

--- a/compose/src/commonMain/kotlin/com/br/kmpdemo/compose/ui/weatherDetails/rainFall/RainFallWidget.kt
+++ b/compose/src/commonMain/kotlin/com/br/kmpdemo/compose/ui/weatherDetails/rainFall/RainFallWidget.kt
@@ -10,43 +10,50 @@ import com.br.kmpdemo.compose.resources.SharedRes
 import com.br.kmpdemo.compose.resources.theme.Dimens
 import com.br.kmpdemo.compose.resources.theme.bold
 import com.br.kmpdemo.compose.resources.theme.letterSpacing
+import com.br.kmpdemo.compose.ui.home.HomeState
 import com.br.kmpdemo.compose.ui.weatherDetails.DetailsWidgetLabel
 import com.br.kmpdemo.compose.ui.weatherDetails.WeatherDetailsSurface
+import com.br.kmpdemo.utils.MeasurementType
 import dev.icerock.moko.resources.compose.stringResource
 
 @Composable
-fun RainFallWidget(rainFallState: RainFallState) {
-    WeatherDetailsSurface(
-        content = {
-            DetailsWidgetLabel(
-                icon = SharedRes.images.raindrop,
-                iconDesc = SharedRes.strings.rainfall,
-                label = SharedRes.strings.rainfall,
-            )
+fun RainFallWidget(state: HomeState) {
+    val isMetric = state.measurementPref.value == MeasurementType.METRIC
+    val rainFallUnit = if (isMetric) SharedRes.strings.input_rainfall_mm else SharedRes.strings.input_rainfall_in
 
-            /// TODO: Create conditional for Metric/Imperial setting
-            Text(
-                rainFallState.currentAccumulation?.let { rain ->
-                    stringResource(SharedRes.strings.input_rainfall_in, rain.toString())
-                } ?: stringResource(SharedRes.strings.empty_digits_error),
-                modifier = Modifier.padding(top = Dimens.grid_1_5),
-                style = MaterialTheme.typography.titleMedium.letterSpacing(0.96.sp)
-            )
+    with(state.rainFallState) {
+        WeatherDetailsSurface(
+            content = {
+                DetailsWidgetLabel(
+                    icon = SharedRes.images.raindrop,
+                    iconDesc = SharedRes.strings.rainfall,
+                    label = SharedRes.strings.rainfall,
+                )
 
-            Text(
-                stringResource(SharedRes.strings.in_last_hour),
-                style = MaterialTheme.typography.bodyMedium.bold()
-            )
+                Text(
+                    value?.currentAccumulation?.let { rain ->
+                        stringResource(rainFallUnit, rain.toString())
+                    } ?: stringResource(SharedRes.strings.empty_digits_error),
+                    modifier = Modifier.padding(top = Dimens.grid_1_5),
+                    style = MaterialTheme.typography.titleMedium.letterSpacing(0.96.sp)
+                )
 
-            Text(
-                stringResource(
-                    SharedRes.strings.input_expected_rainfall,
-                    rainFallState.expectedAccumulation
-                        ?: stringResource(SharedRes.strings.empty_digits_error)
-                ),
-                modifier = Modifier.padding(top = Dimens.grid_2_5),
-                style = MaterialTheme.typography.labelLarge
-            )
-        }
-    )
+                Text(
+                    stringResource(SharedRes.strings.in_last_hour),
+                    style = MaterialTheme.typography.bodyMedium.bold()
+                )
+
+                Text(
+                    stringResource(
+                        SharedRes.strings.input_expected_rainfall,
+                        value?.expectedAccumulation
+                            ?: stringResource(SharedRes.strings.empty_digits_error)
+                    ),
+                    modifier = Modifier.padding(top = Dimens.grid_2_5),
+                    style = MaterialTheme.typography.labelLarge
+                )
+            }
+        )
+    }
+
 }

--- a/compose/src/commonMain/kotlin/com/br/kmpdemo/compose/ui/weatherDetails/visibility/VisibilityWidget.kt
+++ b/compose/src/commonMain/kotlin/com/br/kmpdemo/compose/ui/weatherDetails/visibility/VisibilityWidget.kt
@@ -7,35 +7,44 @@ import androidx.compose.ui.unit.sp
 import com.br.kmpdemo.compose.resources.SharedRes
 import com.br.kmpdemo.compose.resources.theme.Dimens
 import com.br.kmpdemo.compose.resources.theme.letterSpacing
+import com.br.kmpdemo.compose.ui.home.HomeState
 import com.br.kmpdemo.compose.ui.weatherDetails.DetailsWidgetLabel
 import com.br.kmpdemo.compose.ui.weatherDetails.WeatherDetailsSurface
-import com.br.kmpdemo.compose.ui.weatherDetails.visibility.VisibilityState
+import com.br.kmpdemo.utils.MeasurementType
 import dev.icerock.moko.resources.compose.stringResource
 
 @Composable
-fun VisibilityWidget(visibilityState: VisibilityState) {
-    WeatherDetailsSurface(
-        content = {
-            DetailsWidgetLabel(
-                icon = SharedRes.images.visibility_icon,
-                iconDesc = SharedRes.strings.visibility,
-                label = SharedRes.strings.visibility,
-            )
+fun VisibilityWidget(state: HomeState) {
+    val isMetric = state.measurementPref.value == MeasurementType.METRIC
+    val visibilityUnit =
+        if (isMetric) SharedRes.strings.visibility_km else SharedRes.strings.visibility_miles
+    val visibilityInputUnit =
+        if (isMetric) SharedRes.strings.input_visibility_km else SharedRes.strings.input_visibility_mph
 
-            // TODO: Add metric/imperial conditional
-            Text(
-                visibilityState.currentVisibility?.let { visibility ->
-                    stringResource(SharedRes.strings.input_visibility_mph, visibility)
-                } ?: stringResource(SharedRes.strings.empty_digits_error),
-                modifier = Modifier.padding(top = Dimens.grid_2),
-                style = MaterialTheme.typography.titleLarge.letterSpacing(0.96.sp)
-            )
+    with(state.visibilityState) {
+        WeatherDetailsSurface(
+            content = {
+                DetailsWidgetLabel(
+                    icon = SharedRes.images.visibility_icon,
+                    iconDesc = SharedRes.strings.visibility,
+                    label = SharedRes.strings.visibility,
+                )
 
-            Text(
-                stringResource(SharedRes.strings.visibility_miles),
-                modifier = Modifier.padding(top = Dimens.grid_3),
-                style = MaterialTheme.typography.labelLarge
-            )
-        }
-    )
+                Text(
+                    value?.currentVisibility?.let { visibility ->
+                        stringResource(visibilityInputUnit, visibility)
+                    } ?: stringResource(SharedRes.strings.empty_digits_error),
+                    modifier = Modifier.padding(top = Dimens.grid_2),
+                    style = MaterialTheme.typography.titleLarge.letterSpacing(0.96.sp)
+                )
+
+                Text(
+                    stringResource(visibilityUnit),
+                    modifier = Modifier.padding(top = Dimens.grid_3),
+                    style = MaterialTheme.typography.labelLarge
+                )
+            }
+        )
+    }
+
 }

--- a/compose/src/commonMain/kotlin/com/br/kmpdemo/compose/ui/weatherDetails/wind/WindWidget.kt
+++ b/compose/src/commonMain/kotlin/com/br/kmpdemo/compose/ui/weatherDetails/wind/WindWidget.kt
@@ -12,6 +12,7 @@ import com.br.kmpdemo.compose.resources.SharedRes
 import com.br.kmpdemo.compose.resources.theme.Colors
 import com.br.kmpdemo.compose.resources.theme.Dimens
 import com.br.kmpdemo.compose.resources.theme.bold
+import com.br.kmpdemo.compose.ui.home.HomeState
 import com.br.kmpdemo.compose.ui.utils.drawCardinalLabels
 import com.br.kmpdemo.compose.ui.utils.drawCardinalLines
 import com.br.kmpdemo.compose.ui.utils.drawCompassGauge
@@ -20,20 +21,23 @@ import com.br.kmpdemo.compose.ui.utils.drawNorthArrow
 import com.br.kmpdemo.compose.ui.utils.drawWindSpeedText
 import com.br.kmpdemo.compose.ui.weatherDetails.DetailsWidgetLabel
 import com.br.kmpdemo.compose.ui.weatherDetails.WeatherDetailsSurface
+import com.br.kmpdemo.utils.MeasurementType
 import dev.icerock.moko.resources.compose.stringResource
 
 @Composable
-fun WindWidget(state: WindState) {
+fun WindWidget(state: HomeState) {
     val themeTertiary = Colors.onTertiary
     val cardinalStyle = MaterialTheme.typography.labelLarge.copy(color = Colors.onPrimary).bold()
     val windSpeedStyle = MaterialTheme.typography.titleSmall.copy(color = Colors.onPrimary).bold()
-    val perHourStyle = MaterialTheme.typography.bodySmall.copy(color = Colors.onPrimary.copy(alpha = 0.5F)).bold()
+    val perHourStyle =
+        MaterialTheme.typography.bodySmall.copy(color = Colors.onPrimary.copy(alpha = 0.5F)).bold()
     val errorString = stringResource(SharedRes.strings.empty_digits_error)
     val textMeasurer = rememberTextMeasurer()
 
     // Use LocalDensity to convert dp units to pixel units
     val density = LocalDensity.current
-    val windMph = stringResource(SharedRes.strings.wind_mph)
+    val isMetric = state.measurementPref.value == MeasurementType.METRIC
+    val windSpeedUnit = stringResource(if (isMetric) SharedRes.strings.wind_kmh else SharedRes.strings.wind_mph)
     WeatherDetailsSurface(
         content = {
             DetailsWidgetLabel(
@@ -42,7 +46,7 @@ fun WindWidget(state: WindState) {
                 label = SharedRes.strings.wind,
             )
 
-            with(state) {
+            with(state.windState) {
                 Canvas(
                     modifier = Modifier
                         .fillMaxSize()
@@ -56,15 +60,15 @@ fun WindWidget(state: WindState) {
                         drawNorthArrow()
                         drawCardinalLabels(textMeasurer, cardinalStyle)
                         drawWindSpeedText(
-                            windSpeed ?: errorString,
+                            value?.windSpeed ?: errorString,
                             windSpeedStyle,
                             textMeasurer,
                             perHourStyle,
-                            windMph, // TODO: Add metric/imperial conditional
+                            windSpeedUnit,
                         )
                         // If wind speed or direction is null, do not draw needle
-                        windSpeed?.let {
-                            windDirection?.let { direction ->
+                        value?.windSpeed?.let {
+                            value?.windDirection?.let { direction ->
                                 drawCompassNeedle(windDirection = direction, density = density)
                             }
                         }

--- a/compose/src/commonMain/resources/MR/base/strings.xml
+++ b/compose/src/commonMain/resources/MR/base/strings.xml
@@ -13,6 +13,8 @@
     <string name="temp_high_low">H:%1s°   L:%2s°</string>
     <string name="hourly_forecast">Hourly Forecast</string>
     <string name="weekly_forecast">Weekly Forecast</string>
+    <string name="pref_metric">metric</string>
+    <string name="pref_imperial">imperial</string>
 
     <!-- Weather Enum Icon Descriptions -->
     <string name="fog">Fog</string>

--- a/data/src/commonMain/kotlin/com/br/kmpdemo/network/NetworkRoutes.kt
+++ b/data/src/commonMain/kotlin/com/br/kmpdemo/network/NetworkRoutes.kt
@@ -10,7 +10,6 @@ package com.br.kmpdemo.network
  *      Must use [DAILY_FORECAST] to access some fields like sunriseTime and sunsetTime
  *      Use [HOURLY_FORECAST] to access hourly forecast data
  *      Use [REALTIME_FORECAST] to access current weather data for WeatherWidget
- * - For UNITS (optional), use [METRIC] or [IMPERIAL]
  **/
 object NetworkRoutes {
     const val BASE_URL = "https://api.tomorrow.io/v4/weather"
@@ -21,6 +20,4 @@ object NetworkRoutes {
     const val DAILY_FORECAST = "1d"
     const val HOURLY_FORECAST = "1h"
     const val REALTIME_FORECAST = "current"
-    const val METRIC = "metric"
-    const val IMPERIAL = "imperial" // TODO: Default to imperial until metric is available
 }

--- a/domain/src/commonMain/kotlin/com/br/kmpdemo/utils/MeasurementType.kt
+++ b/domain/src/commonMain/kotlin/com/br/kmpdemo/utils/MeasurementType.kt
@@ -1,0 +1,6 @@
+package com.br.kmpdemo.utils
+
+enum class MeasurementType(val type: String) {
+    METRIC("metric"),
+    IMPERIAL("imperial")
+}

--- a/shared/src/androidMain/kotlin/PlatformSpecificUtils.android.kt
+++ b/shared/src/androidMain/kotlin/PlatformSpecificUtils.android.kt
@@ -1,8 +1,13 @@
+import android.content.Context
+import android.content.SharedPreferences
 import androidx.compose.material3.ColorScheme
 import com.br.kmpdemo.compose.resources.theme.Dimensions
 import com.br.kmpdemo.compose.resources.theme.kmpDarkColors
 import com.br.kmpdemo.compose.resources.theme.kmpLightColors
 import com.br.kmpdemo.compose.resources.theme.sw360Dimensions
+import com.br.kmpdemo.utils.Constants.IS_METRIC
+import com.br.kmpdemo.utils.Constants.MEASUREMENT_PREFS
+import com.br.kmpdemo.utils.MeasurementType
 
 actual fun getSystemDimensions(): Dimensions {
     // Return iOS-specific dimensions
@@ -16,4 +21,18 @@ actual fun getSystemColorScheme(darkTheme: Boolean): ColorScheme {
     } else {
         kmpLightColors
     }
+}
+
+actual object MeasurementPreference {
+    private lateinit var preferences: SharedPreferences
+
+    fun init(context: Context) {
+        preferences = context.getSharedPreferences(MEASUREMENT_PREFS, Context.MODE_PRIVATE)
+    }
+
+    actual var preference: MeasurementType
+        get() = if (preferences.getBoolean(IS_METRIC, false)) MeasurementType.IMPERIAL else MeasurementType.METRIC
+        set(value) {
+            preferences.edit().putBoolean(IS_METRIC, value == MeasurementType.METRIC).apply()
+        }
 }

--- a/shared/src/commonMain/kotlin/PlatformSpecificUtils.kt
+++ b/shared/src/commonMain/kotlin/PlatformSpecificUtils.kt
@@ -1,5 +1,11 @@
+
 import androidx.compose.material3.ColorScheme
 import com.br.kmpdemo.compose.resources.theme.Dimensions
+import com.br.kmpdemo.utils.MeasurementType
 
 expect fun getSystemDimensions(): Dimensions
 expect fun getSystemColorScheme(darkTheme: Boolean): ColorScheme
+
+expect object MeasurementPreference {
+    var preference: MeasurementType
+}

--- a/shared/src/commonMain/kotlin/com/br/kmpdemo/utils/Constants.kt
+++ b/shared/src/commonMain/kotlin/com/br/kmpdemo/utils/Constants.kt
@@ -1,0 +1,6 @@
+package com.br.kmpdemo.utils
+
+object Constants {
+    const val IS_METRIC = "isMetric"
+    const val MEASUREMENT_PREFS = "measurement_prefs"
+}

--- a/shared/src/commonMain/kotlin/com/br/kmpdemo/viewmodels/HomeViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/br/kmpdemo/viewmodels/HomeViewModel.kt
@@ -1,6 +1,7 @@
 package com.br.kmpdemo.viewmodels
 
 import BaseViewModel
+import MeasurementPreference
 import co.touchlab.kermit.Logger
 import com.br.kmpdemo.compose.ui.forecasts.ForecastState
 import com.br.kmpdemo.compose.ui.forecasts.WeatherEnum
@@ -17,7 +18,6 @@ import com.br.kmpdemo.compose.ui.weatherDetails.wind.WindState
 import com.br.kmpdemo.compose.ui.weatherDetails.wind.getWindDirection
 import com.br.kmpdemo.models.Forecast
 import com.br.kmpdemo.models.RealTime
-import com.br.kmpdemo.network.NetworkRoutes
 import com.br.kmpdemo.repositories.WeatherRepository
 import com.br.kmpdemo.viewmodels.HomeViewModelUtils.convertUtcTimeForSunriseSunset
 import com.br.kmpdemo.viewmodels.HomeViewModelUtils.extractCityName
@@ -34,6 +34,7 @@ import org.koin.core.component.inject
 
 class HomeViewModel : BaseViewModel() {
     private val weatherRepo: WeatherRepository by inject()
+    val measurementPref = MutableStateFlow(MeasurementPreference.preference)
 
     /**region Forecast Responses */
     val initForecasts = List(10) { ForecastState(weatherIcon = WeatherEnum.SUNNY) }
@@ -120,23 +121,23 @@ class HomeViewModel : BaseViewModel() {
 
 
     /**region Network calls */
-    private fun getDailyForecasts(location: String, units: String = NetworkRoutes.IMPERIAL) =
+    private fun getDailyForecasts(location: String) =
         viewModelScope.launch {
-            weatherRepo.getDailyForecast(location = location, units = units)
+            weatherRepo.getDailyForecast(location = location, units = measurementPref.value.type)
                 .onSuccess { dailyResponse.value = it }
                 .onFailure { Logger.e("[getDailyForecasts]") { "Failure: ${it.message}" } }
         }
 
-    private fun getHourlyForecasts(location: String, units: String = NetworkRoutes.IMPERIAL) =
+    private fun getHourlyForecasts(location: String) =
         viewModelScope.launch {
-            weatherRepo.getHourlyForecast(location = location, units = units)
+            weatherRepo.getHourlyForecast(location = location, units = measurementPref.value.type)
                 .onSuccess { hourlyResponse.value = it }
                 .onFailure { Logger.e("[getHourlyForecasts]") { "Failure: ${it.message}" } }
         }
 
-    private fun getRealTimeForecasts(location: String, units: String = NetworkRoutes.IMPERIAL) =
+    private fun getRealTimeForecasts(location: String) =
         viewModelScope.launch {
-            weatherRepo.getRealTimeForecast(location, units = units)
+            weatherRepo.getRealTimeForecast(location, units = measurementPref.value.type)
                 .onSuccess { realTimeResponse.value = it }
                 .onFailure { Logger.e("[getRealTimeForecasts]") { "Failure: ${it.message}" } }
         }

--- a/shared/src/commonMain/kotlin/com/br/kmpdemo/viewmodels/converters/HomeStateConverter.kt
+++ b/shared/src/commonMain/kotlin/com/br/kmpdemo/viewmodels/converters/HomeStateConverter.kt
@@ -3,6 +3,7 @@ package com.br.kmpdemo.viewmodels.converters
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import com.br.kmpdemo.compose.ui.home.HomeState
+import com.br.kmpdemo.utils.MeasurementType
 import com.br.kmpdemo.viewmodels.HomeViewModel
 
 @Composable
@@ -27,4 +28,7 @@ fun HomeViewModel.toState() = HomeState(
     uvIndexState = uvIndexState.collectAsState(null),
     visibilityState = visibilityState.collectAsState(null),
     windState = windState.collectAsState(null),
+
+    // Units
+    measurementPref = measurementPref.collectAsState(MeasurementType.IMPERIAL),
 )

--- a/shared/src/iosMain/kotlin/PlatformSpecificUtils.kt
+++ b/shared/src/iosMain/kotlin/PlatformSpecificUtils.kt
@@ -1,8 +1,12 @@
+
 import androidx.compose.material3.ColorScheme
 import com.br.kmpdemo.compose.resources.theme.Dimensions
 import com.br.kmpdemo.compose.resources.theme.kmpDarkColors
 import com.br.kmpdemo.compose.resources.theme.kmpLightColors
 import com.br.kmpdemo.compose.resources.theme.sw360Dimensions
+import com.br.kmpdemo.utils.Constants.IS_METRIC
+import com.br.kmpdemo.utils.MeasurementType
+import platform.Foundation.NSUserDefaults
 
 actual fun getSystemDimensions(): Dimensions {
     // Return iOS-specific dimensions
@@ -16,4 +20,15 @@ actual fun getSystemColorScheme(darkTheme: Boolean): ColorScheme {
     } else {
         kmpLightColors
     }
+}
+
+actual object MeasurementPreference {
+    private val userDefaults: NSUserDefaults = NSUserDefaults.standardUserDefaults
+
+    actual var preference: MeasurementType
+        get() = if (userDefaults.boolForKey(IS_METRIC)) MeasurementType.METRIC else MeasurementType.IMPERIAL
+        set(value) {
+            userDefaults.setBool(value == MeasurementType.METRIC, IS_METRIC)
+            userDefaults.synchronize()
+        }
 }


### PR DESCRIPTION
### [[ASAA-190] Global Setting for Metric/Imperial](https://bottlerocketstudios.atlassian.net/browse/ASAA-190)
- Added a value for `measurementPref` in HomeState and the HomeStateConverter
- Added a flow to HomeViewModel to access the `measurementPref` from shared prefs
- Removed the argument for `units` from API calls and added the `measurementPref` flow to the calls
- Fixed an error for precip probability in Hourly and Daily chips
- Added the `MeasurementPreference.init` function to KmpDemoApplication to initialize Shared Prefs
- Removed METRIC and IMPERIAL constants from NetworkRoutes
- Update PlatformSpecificUtils for platform specific storage of the users preferred measurement system
- Updated RainFallWidget, VisibilityWidget, and WindWidget with conditionals to reflect the users preferred measurement system
- Update `WeatherDetails` to pass HomeState so the above widgets have access to the `measurementPref` flow
- Added a Constants file in shared module for `MeasurementPreference`
- Added enum class for MeasurementType